### PR TITLE
ci: install dependencies & setup WSL1 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
         node-version: [10.x, 12.x]
-
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
@@ -49,4 +48,51 @@ jobs:
           env_vars: CI_OS,NODE_VERSION
         env:
           CI_OS: ${{ matrix.os }}
+          NODE_VERSION: ${{ matrix.node-version }}
+
+  build-wsl:
+    defaults:
+      run:
+        shell: wsl-bash {0}
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [10.x]
+    steps:
+      - name: Fix git checkout line endings
+        run: git config --global core.autocrlf input
+        shell: pwsh
+      - uses: Vampire/setup-wsl@v1
+      - name: WSL kernel version
+        run: uname --kernel-release
+      - uses: actions/checkout@v2
+      - name: Determine WSL version of workspace
+        id: wsl-workspace
+        run: echo "::set-output name=dir::$(wslpath '${{ github.workspace }}')"
+      - name: Move repo to WSL
+        run: cp -R ${{ steps.wsl-workspace.outputs.dir }} $HOME/
+      - name: Setup Node.js
+        run: ci/setup-node-wsl.sh ${{ matrix.node-version }}
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: Linux-yarn-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            Linux-yarn-
+      - name: Install
+        run: cd $HOME/cross-spawn-windows-exe && yarn
+      - name: Lint
+        run: cd $HOME/cross-spawn-windows-exe && yarn lint
+      - name: Test
+        run: cd $HOME/cross-spawn-windows-exe && CSWE_TEST_FIXTURES=${{ steps.wsl-workspace.outputs.dir }}/test/fixtures yarn coverage && mv coverage ${{ steps.wsl-workspace.outputs.dir }}/
+      - name: Upload code coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage/lcov.info
+          env_vars: CI_OS,NODE_VERSION
+        env:
+          CI_OS: WSL
           NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
@@ -57,7 +57,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           CI_OS: ${{ matrix.os }}
           NODE_VERSION: ${{ matrix.node-version }}
 
-  build-wsl:
+  build-wsl1:
     defaults:
       run:
         shell: wsl-bash {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v2
+      - name: Install platform dependencies
+        shell: bash
+        run: ci/install_dependencies.sh
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:

--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+case "$(uname -s)" in
+  Linux)
+    sudo apt-get install --yes mono-devel wine-stable
+    ;;
+  Darwin)
+    brew cask install xquartz wine-stable
+    wine64 hostname
+    ;;
+esac

--- a/ci/setup-node-wsl.sh
+++ b/ci/setup-node-wsl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+NODE_VERSION="$1"
+
+echo "Installing Node ${NODE_VERSION}..."
+echo
+
+set -eou pipefail
+
+sudo apt-get update
+sudo apt-get install --yes --no-install-recommends curl ca-certificates apt-transport-https
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | sudo -E bash -
+sudo apt-get install --yes --no-install-recommends nodejs yarn

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     ],
     "require": [
       "ts-node/register"
-    ]
+    ],
+    "timeout": "3m"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/test/dotnet.ts
+++ b/test/dotnet.ts
@@ -3,7 +3,8 @@ import { determineDotNetWrapper, spawnDotNet } from "../src/dotnet";
 import { normalizePath } from "../src/normalize-path";
 import test from "ava";
 
-const fixturePath = path.resolve(__dirname, "fixtures");
+const fixturePath =
+  process.env.CSWE_TEST_FIXTURES || path.resolve(__dirname, "fixtures");
 
 // Tests are serial because changing environment variables isn't threadsafe.
 

--- a/test/exe.ts
+++ b/test/exe.ts
@@ -6,6 +6,8 @@ import * as sinon from "sinon";
 import test from "ava";
 
 const fixturePath = path.resolve(__dirname, "fixtures");
+// Timeout is in ms. For some bizarre reason, macOS Wine in CI takes forever.
+const wineTimeout = process.platform === "darwin" ? 180_000 : 60_000;
 
 // Tests are serial because changing environment variables isn't threadsafe.
 
@@ -46,7 +48,7 @@ test.serial(
 test.serial("runs a Windows binary", async (t) => {
   t.is(process.env.WINE_BINARY, undefined);
   if (!canRunWindowsExeNatively()) {
-    t.timeout(20_000, "wine is taking too long to execute");
+    t.timeout(wineTimeout, "wine is taking too long to execute");
   }
   const output = await spawnExe(path.join(fixturePath, "hello.exe"));
   t.is(output.trim(), "Hello EXE World");
@@ -55,7 +57,7 @@ test.serial("runs a Windows binary", async (t) => {
 test.serial("runs a Windows binary with arguments", async (t) => {
   t.is(process.env.WINE_BINARY, undefined);
   if (!canRunWindowsExeNatively()) {
-    t.timeout(10_000, "wine is taking too long to execute");
+    t.timeout(wineTimeout, "wine is taking too long to execute");
   }
   const output = await spawnExe(path.join(fixturePath, "hello.exe"), [
     "argument.txt",
@@ -69,7 +71,7 @@ test.serial("runs a Windows binary with arguments", async (t) => {
 test.serial("runs a Windows binary with a filename argument", async (t) => {
   t.is(process.env.WINE_BINARY, undefined);
   if (!canRunWindowsExeNatively()) {
-    t.timeout(10_000, "wine is taking too long to execute");
+    t.timeout(wineTimeout, "wine is taking too long to execute");
   }
   const output = await spawnExe(path.join(fixturePath, "hello.exe"), [
     await normalizePath(path.join(fixturePath, "input.txt")),

--- a/test/exe.ts
+++ b/test/exe.ts
@@ -5,7 +5,8 @@ import * as path from "path";
 import * as sinon from "sinon";
 import test from "ava";
 
-const fixturePath = path.resolve(__dirname, "fixtures");
+const fixturePath =
+  process.env.CSWE_TEST_FIXTURES || path.resolve(__dirname, "fixtures");
 // Timeout is in ms. For some bizarre reason, macOS Wine in CI takes forever.
 const wineTimeout = process.platform === "darwin" ? 180_000 : 60_000;
 

--- a/test/normalize-path.ts
+++ b/test/normalize-path.ts
@@ -4,13 +4,13 @@ import test from "ava";
 
 if (isWSL) {
   test("convertUNIXPathToWindows: converts a UNIX-style path", async (t) => {
-    const actual = await normalizePath("/tmp/foo");
-    t.regex(actual, /\\wsl\$/);
+    const actual = await normalizePath("/mnt/c/Windows");
+    t.is(actual, "C:\\Windows");
   });
 
   test("normalizePath: converts input for WSL", async (t) => {
-    const actual = await normalizePath("/tmp/foo");
-    t.regex(actual, /\\wsl\$/);
+    const actual = await normalizePath("/mnt/c/Windows");
+    t.is(actual, "C:\\Windows");
   });
 } else {
   test("convertUNIXPathToWindows: fails with human-friendly message about missing wslpath", async (t) => {

--- a/test/normalize-path.ts
+++ b/test/normalize-path.ts
@@ -15,7 +15,7 @@ if (isWSL) {
 } else {
   test("convertUNIXPathToWindows: fails with human-friendly message about missing wslpath", async (t) => {
     await t.throwsAsync(convertUNIXPathToWindows("/tmp/foo"), {
-      message: `Error executing command (wslpath -w /tmp/foo):\nCould not find 'wslpath' in any of the directories listed in the PATH environment variable, which is needed to convert WSL paths to Windows-style paths.`,
+      message: /Error executing command \(wslpath -w \/tmp\/foo\):\nCould not find 'wslpath' in any of the directories listed in the PATH environment variable, which is needed to convert WSL paths to Windows-style paths/,
     });
   });
 


### PR DESCRIPTION
## Description of Change

* Make sure dependencies are installed
* Test on WSL
* Test on major supported Node versions

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).
- [x] macOS/Linux dependencies are installed
- [x] Test on WSL1
- [x] Remove any `[REMOVEME]` commits

## Lessons Learned

* Wine on macOS is incredibly slow.
* GitHub Actions can only install WSL1, not WSL2. I think this is because they're using Windows Server 2019, which may not support WSL2?
* `wslpath` does not work with paths that don't exist (even if the rest of the directory structure exists)
* `wslpath` does not work with Linux paths not in `/mnt`
* Unsurprisingly, a lot of Actions functionality does not work with WSL. This includes environment variables, `actions/setup-node`, and working directory.