### PR TITLE
test: add tests for spaces in the filename

### DIFF
--- a/test/exe.ts
+++ b/test/exe.ts
@@ -82,3 +82,20 @@ test.serial("runs a Windows binary with a filename argument", async (t) => {
     "Hello EXE World, arguments passed\nInput\nFile"
   );
 });
+
+test.serial(
+  "runs a Windows binary with a filename argument containing a space",
+  async (t) => {
+    t.is(process.env.WINE_BINARY, undefined);
+    if (!canRunWindowsExeNatively()) {
+      t.timeout(wineTimeout, "wine is taking too long to execute");
+    }
+    const output = await spawnExe(path.join(fixturePath, "hello.exe"), [
+      await normalizePath(path.join(fixturePath, "input with space.txt")),
+    ]);
+    t.is(
+      output.trim().replace(/\r/g, ""),
+      "Hello EXE World, arguments passed\nInput\nFile With Space"
+    );
+  }
+);

--- a/test/fixtures/input with space.txt
+++ b/test/fixtures/input with space.txt
@@ -1,0 +1,2 @@
+Input
+File With Space

--- a/test/normalize-path.ts
+++ b/test/normalize-path.ts
@@ -12,6 +12,11 @@ if (isWSL) {
     const actual = await normalizePath("/mnt/c/Windows");
     t.is(actual, "C:\\Windows");
   });
+
+  test("normalizePath: converts input with spaces for WSL", async (t) => {
+    const actual = await normalizePath("/mnt/c/Program Files");
+    t.is(actual, "C:\\Program Files");
+  });
 } else {
   test("convertUNIXPathToWindows: fails with human-friendly message about missing wslpath", async (t) => {
     await t.throwsAsync(convertUNIXPathToWindows("/tmp/foo"), {


### PR DESCRIPTION
## Description of Change

* Add test for normalize path (WSL) for a path with spaces
* Add test for EXE for an argument with spaces

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).
