### PR TITLE
ci: use setup-wsl fork to fix add-path failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
         shell: pwsh
-      - uses: Vampire/setup-wsl@v1
+      - uses: malept/setup-wsl@malept/chore/upgrade-actions-core-1.2.6
       - name: WSL kernel version
         run: uname --kernel-release
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
         shell: pwsh
-      - uses: malept/setup-wsl@malept/chore/upgrade-actions-core-1.2.6
+      - uses: malept/setup-wsl@v1test
       - name: WSL kernel version
         run: uname --kernel-release
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description of Change

Attempt to fix [test failure](https://github.com/malept/cross-spawn-windows-exe/pull/5/checks?check_run_id=1413242180#step:3:22) myself.
## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
