### PR TITLE
fix: use newer brew install syntax

### DIFF
--- a/ci/install_dependencies.sh
+++ b/ci/install_dependencies.sh
@@ -7,7 +7,7 @@ case "$(uname -s)" in
     sudo apt-get install --yes mono-devel wine-stable
     ;;
   Darwin)
-    brew cask install xquartz wine-stable
+    brew install --cask xquartz wine-stable
     wine64 hostname
     ;;
 esac

--- a/src/exe.ts
+++ b/src/exe.ts
@@ -7,7 +7,7 @@ function installInstructions(): string {
     case "win32":
       return "No wrapper necessary";
     case "darwin":
-      return "Run `brew cask install wine-stable` to install 64-bit wine on macOS via Homebrew.";
+      return "Run `brew install --cask wine-stable` to install 64-bit wine on macOS via Homebrew.";
     case "linux":
       return "Consult your Linux distribution's package manager to determine how to install Wine.";
     /* istanbul ignore next */


### PR DESCRIPTION
## Description of Change

This fixes the warning:

```
Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
```

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
- [x] The changes have sufficient test coverage (if applicable).
