### PR TITLE
ci: extract lint step to its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,34 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fix git checkout line endings
+        run: git config --global core.autocrlf input
+      - uses: actions/checkout@v2
+      - name: Install platform dependencies
+        shell: bash
+        run: ci/install_dependencies.sh
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 10.x
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2.1.4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        run: yarn
+      - name: Lint
+        run: yarn lint
   build:
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,8 +64,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install
         run: yarn
-      - name: Lint
-        run: yarn lint
       - name: Test
         run: yarn coverage
       - name: Upload code coverage to Codecov
@@ -51,6 +76,7 @@ jobs:
           NODE_VERSION: ${{ matrix.node-version }}
 
   build-wsl1:
+    needs: lint
     defaults:
       run:
         shell: wsl-bash {0}
@@ -84,8 +110,6 @@ jobs:
             Linux-yarn-
       - name: Install
         run: cd $HOME/cross-spawn-windows-exe && yarn
-      - name: Lint
-        run: cd $HOME/cross-spawn-windows-exe && yarn lint
       - name: Test
         run: cd $HOME/cross-spawn-windows-exe && CSWE_TEST_FIXTURES=${{ steps.wsl-workspace.outputs.dir }}/test/fixtures yarn coverage && mv coverage ${{ steps.wsl-workspace.outputs.dir }}/
       - name: Upload code coverage to Codecov


### PR DESCRIPTION
## Description of Change

Failing linting should hard-fail a PR, before it tries to run tests on Windows/macOS/WSL1 (which are slow).

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
