### PR TITLE
ci(wsl): ensure gnupg2 is installed before Node.js is installed

### DIFF
--- a/ci/setup-node-wsl.sh
+++ b/ci/setup-node-wsl.sh
@@ -8,7 +8,7 @@ echo
 set -eou pipefail
 
 sudo apt-get update
-sudo apt-get install --yes --no-install-recommends curl ca-certificates apt-transport-https
+sudo apt-get install --yes --no-install-recommends curl ca-certificates apt-transport-https gnupg2
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | sudo -E bash -


### PR DESCRIPTION
## Description of Change

Fixes recent failures in WSL1 CI.

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
