### PR TITLE
feat: add is64BitArch

### DIFF
--- a/src/arch.ts
+++ b/src/arch.ts
@@ -1,0 +1,11 @@
+// List of Node.js-formatted 64 bit arches
+const SIXTY_FOUR_BIT_ARCHES = ["arm64", "x64"];
+
+/**
+ * Determines whether the given architecture is a 64-bit arch.
+ *
+ * @param arch - a Node.js-style architecture name
+ */
+export function is64BitArch(arch: string): boolean {
+  return SIXTY_FOUR_BIT_ARCHES.includes(arch);
+}

--- a/src/exe.ts
+++ b/src/exe.ts
@@ -1,5 +1,6 @@
 import { CrossSpawnArgs } from "@malept/cross-spawn-promise";
 import { CrossSpawnExeOptions, spawnWrapperFromFunction } from "./wrapper";
+import { is64BitArch } from "./arch";
 
 function installInstructions(): string {
   switch (process.platform) {
@@ -36,7 +37,7 @@ export function determineWineWrapper(customWinePath?: string): string {
     return process.env.WINE_BINARY;
   }
 
-  if (process.arch === "x64") {
+  if (is64BitArch(process.arch)) {
     return "wine64";
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   spawnWrapperFromFunction,
 } from "./wrapper";
 
+export { is64BitArch } from "./arch";
 export { normalizePath } from "./normalize-path";
 
 export { spawnDotNet } from "./dotnet";

--- a/test/arch.ts
+++ b/test/arch.ts
@@ -1,0 +1,18 @@
+import { is64BitArch } from "../src/arch";
+import test from "ava";
+
+test("arm64 is a 64-bit arch", (t) => {
+  t.true(is64BitArch("arm64"));
+});
+
+test("x64 is a 64-bit arch", (t) => {
+  t.true(is64BitArch("x64"));
+});
+
+test("ia32 is not a 64-bit arch", (t) => {
+  t.false(is64BitArch("ia32"));
+});
+
+test("armv7l is not a 64-bit arch", (t) => {
+  t.false(is64BitArch("armv7l"));
+});


### PR DESCRIPTION
## Description of Change

Fixes the case where `wine` is run on a Mac M1 (i.e., darwin/arm64).

Exports the function as well to be able to use this to determine whether to use a 32-bit or 64-bit `exe`. That's why this PR is a feature and not a bugfix.

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).
