### PR TITLE
feat!: require Node.js 12 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     # Check the npm registry for updates every weekday
     schedule:
       interval: "daily"
-    ignore:
-      # Does not work with typedoc 0.20.x
-      - dependency-name: "typescript"
-        versions: ["^4.3.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.4.0
         with:
-          node-version: 10.x
+          node-version: 12.x
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
@@ -83,7 +83,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilizes [`@malept/cross-spawn-promise`](https://npm.im/@malept/cross-spawn-prom
 extension, [`cross-spawn`](https://npm.im/cross-spawn)) to execute Windows executables regardless
 of platform.
 
-For all platforms, Node 10 or above is required.
+For all platforms, Node 12.13.0 (LTS) or above is required.
 
 On non-Windows, non-WSL host systems, the following dependencies are required:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilizes [`@malept/cross-spawn-promise`](https://npm.im/@malept/cross-spawn-prom
 extension, [`cross-spawn`](https://npm.im/cross-spawn)) to execute Windows executables regardless
 of platform.
 
-For all platforms, Node 12.13.0 (LTS) or above is required.
+For all platforms, Node.js 12.13.0 (LTS) or above is required.
 
 On non-Windows, non-WSL host systems, the following dependencies are required:
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@malept/eslint-config": "^1.1.2",
     "@types/node": "^16.0.0",
     "@types/sinon": "^10.0.0",
     "@types/which": "^2.0.0",
@@ -75,26 +76,9 @@
     "timeout": "3m"
   },
   "eslintConfig": {
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaVersion": "2019",
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@typescript-eslint",
-      "eslint-plugin-tsdoc"
-    ],
     "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:ava/recommended",
-      "plugin:import/errors",
-      "plugin:import/warnings",
-      "plugin:import/typescript",
-      "plugin:node/recommended",
-      "plugin:prettier/recommended",
-      "plugin:promise/recommended",
-      "prettier"
+      "@malept/eslint-config/typescript",
+      "plugin:node/recommended"
     ],
     "rules": {
       "node/no-unsupported-features/es-syntax": [
@@ -104,9 +88,7 @@
             "modules"
           ]
         }
-      ],
-      "strict": "error",
-      "tsdoc/syntax": "warn"
+      ]
     },
     "overrides": [
       {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "yarn lint && yarn ava"
   },
   "dependencies": {
-    "@malept/cross-spawn-promise": "^1.1.0",
+    "@malept/cross-spawn-promise": "^2.0.0",
     "is-wsl": "^2.2.0",
     "which": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prettier": "^2.0.5",
     "sinon": "^11.1.0",
     "source-map-support": "^0.5.19",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.2.1",
     "typedoc": "^0.20.0-beta.24",
     "typescript": "~4.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Mark Lee",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12.13.0"
   },
   "scripts": {
     "ava": "ava",
@@ -77,7 +77,7 @@
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-      "ecmaVersion": "2018",
+      "ecmaVersion": "2019",
       "sourceType": "module"
     },
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "source-map-support": "^0.5.19",
     "ts-node": "^10.2.1",
     "typedoc": "^0.21.6",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.5"
   },
   "ava": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
   "lint-staged": {
     "*.{json,md,yml}": "prettier --write",
     "*.ts": [
-      "prettier --write",
       "eslint --fix"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-tsdoc": "^0.2.5",
-    "husky": "^6.0.0",
+    "husky": "^7.0.1",
     "lint-staged": "^11.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sinon": "^11.1.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.2.1",
-    "typedoc": "^0.20.0-beta.24",
+    "typedoc": "^0.21.6",
     "typescript": "~4.2.4"
   },
   "ava": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2018",
+    "target": "es2019",
     "outDir": "dist",
-    "lib": ["es2018"],
+    "lib": ["es2019"],
     "sourceMap": true,
     "rootDir": ".",
     "strict": true,


### PR DESCRIPTION
## Description of Change

Also upgrades all dependencies.

BREAKING CHANGE: drop support for Node.js < 12.13.0

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-windows-exe/blob/main/CONTRIBUTING.md) for this project.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).
